### PR TITLE
Update to work with Cucumber 4. Fix GitHub selector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 node_modules
+package-lock.json

--- a/features/step_definitions/github.js
+++ b/features/step_definitions/github.js
@@ -1,42 +1,40 @@
-var { defineSupportCode } = require('cucumber');
+var { Given, When, Then } = require('cucumber');
 var Selector       = require('testcafe').Selector;
 var Role           = require('testcafe').Role;
 
-defineSupportCode(function ({ Given, When, Then }) {
-    var testController = null;
+var testController = null;
 
-    Given('I am open GitHub page', function () {
-        return this.waitForTestController()
-            .then(function (tc) {
-                testController = tc;
+Given('I am open GitHub page', function () {
+    return this.waitForTestController()
+        .then(function (tc) {
+            testController = tc;
 
-                return testController.navigateTo('https://github.com/');
-            });
-    });
+            return testController.navigateTo('https://github.com/');
+        });
+});
 
-    When('I am typing my search request {stringInDoubleQuotes} on GitHub', function (text) {
-        var input = Selector('input.form-control.header-search-input.js-site-search-focus').with({ boundTestRun: testController });
+When('I am typing my search request {string} on GitHub', function (text) {
+    var input = Selector('input.form-control.header-search-input.js-site-search-focus').with({ boundTestRun: testController });
 
-        return testController.typeText(input, text);
-    });
+    return testController.typeText(input, text);
+});
 
-    Then('I am pressing {stringInDoubleQuotes} key on GitHub', function (text) {
-        return testController.pressKey(text);
-    });
+Then('I am pressing {string} key on GitHub', function (text) {
+    return testController.pressKey(text);
+});
 
-    Then('I should see that the first GitHub\'s result is {stringInDoubleQuotes}', function (text) {
-        var firstLink = Selector('#js-pjax-container > div.container > div > div.column.three-fourths.codesearch-results > div.pl-2 > ul > div:nth-child(1) > div.col-8.pr-3 > h3 > a').with({ boundTestRun: testController });
+Then('I should see that the first GitHub\'s result is {string}', function (text) {
+    var firstLink = Selector('#js-pjax-container > div.container > div > div.column.three-fourths.codesearch-results > div.pl-2 > ul > div:nth-child(1) > div.col-8.pr-3 > h3 > a').with({ boundTestRun: testController });
 
-        return testController.expect(firstLink.innerText).contains(text);
-    });
+    return testController.expect(firstLink.innerText).contains(text);
+});
 
-    const gitHubRoleForExample = Role('http://github.com/login', function (t) {
-        return t
-            .click('.btn.btn-primary.btn-block')
-            .expect(Selector('#js-flash-container > div > div').innerText).contains("Incorrect username or password.");
-    });
+const gitHubRoleForExample = Role('http://github.com/login', function (t) {
+    return t
+        .click('.btn.btn-primary.btn-block')
+        .expect(Selector('#js-flash-container > div > div').innerText).contains("Incorrect username or password.");
+});
 
-    Then('I am trying to use {Role}', function (text) {
-        return testController.useRole(gitHubRoleForExample);
-    });
+Then('I am trying to use {string}', function (text) {
+    return testController.useRole(gitHubRoleForExample);
 });

--- a/features/step_definitions/github.js
+++ b/features/step_definitions/github.js
@@ -25,7 +25,7 @@ defineSupportCode(function ({ Given, When, Then }) {
     });
 
     Then('I should see that the first GitHub\'s result is {stringInDoubleQuotes}', function (text) {
-        var firstLink = Selector('#js-pjax-container > div.container > div > div.column.three-fourths.codesearch-results.pr-6 > ul > div:nth-child(1) > div.col-8.pr-3 > h3 > a').with({ boundTestRun: testController });
+        var firstLink = Selector('#js-pjax-container > div.container > div > div.column.three-fourths.codesearch-results > div.pl-2 > ul > div:nth-child(1) > div.col-8.pr-3 > h3 > a').with({ boundTestRun: testController });
 
         return testController.expect(firstLink.innerText).contains(text);
     });

--- a/features/step_definitions/google.js
+++ b/features/step_definitions/google.js
@@ -1,31 +1,29 @@
-var { defineSupportCode } = require('cucumber');
+var { Given, When, Then } = require('cucumber');
 var Selector       = require('testcafe').Selector;
 
-defineSupportCode(function ({ Given, When, Then }) {
-    var testController = null;
+var testController = null;
 
-    Given('I am open Google\'s search page', function () {
-        return this.waitForTestController()
-            .then(function (tc) {
-                testController = tc;
+Given('I am open Google\'s search page', function () {
+    return this.waitForTestController()
+        .then(function (tc) {
+            testController = tc;
 
-                return testController.navigateTo('http://google.com');
-            });
-    });
+            return testController.navigateTo('http://google.com');
+        });
+});
 
-    When('I am typing my search request {stringInDoubleQuotes} on Google', function (text) {
-        var input = Selector('#lst-ib').with({ boundTestRun: testController });
+When('I am typing my search request {string} on Google', function (text) {
+    var input = Selector('#lst-ib').with({ boundTestRun: testController });
 
-        return testController.typeText(input, text);
-    });
+    return testController.typeText(input, text);
+});
 
-    Then('I am pressing {stringInDoubleQuotes} key on Google', function (text) {
-        return testController.pressKey(text);
-    });
+Then('I am pressing {string} key on Google', function (text) {
+    return testController.pressKey(text);
+});
 
-    Then('I should see that the first Google\'s result is {stringInDoubleQuotes}', function (text) {
-        var firstLink = Selector('#rso').find('a').with({ boundTestRun: testController });
+Then('I should see that the first Google\'s result is {string}', function (text) {
+    var firstLink = Selector('#rso').find('a').with({ boundTestRun: testController });
 
-        return testController.expect(firstLink.innerText).contains(text);
-    });
+    return testController.expect(firstLink.innerText).contains(text);
 });

--- a/features/step_definitions/hooks.js
+++ b/features/step_definitions/hooks.js
@@ -25,7 +25,7 @@ function runTest () {
 
             return runner
                 .src('./test.js')
-                .browsers('chrome')
+                .browsers('chrome -incognito')
                 .run()
                 .catch(function (error) {
                     console.log(error);

--- a/features/step_definitions/hooks.js
+++ b/features/step_definitions/hooks.js
@@ -1,4 +1,4 @@
-var { defineSupportCode } = require('cucumber');
+var { BeforeAll, AfterAll } = require('cucumber');
 const fs                   = require('fs');
 const createTestCafe       = require('testcafe');
 const testControllerHolder = require('../support/testControllerHolder');
@@ -36,17 +36,16 @@ function runTest () {
         });
 }
 
-defineSupportCode(function ({ registerHandler }) {
-    registerHandler('BeforeFeatures', function (features, callback) {
-        createTestFile();
-        runTest();
+BeforeAll(function (callback) {
+    createTestFile();
+    runTest();
 
-        setTimeout(callback, DELAY);
-    });
+    setTimeout(callback, DELAY);
+});
 
-    registerHandler('AfterFeatures', function (features, callback) {
-        testControllerHolder.free();
-        fs.unlinkSync('test.js');
-        setTimeout(callback, DELAY);
-    });
+AfterAll(function (callback) {
+    testControllerHolder.free();
+    fs.unlinkSync('test.js');
+
+    setTimeout(callback, DELAY);
 });

--- a/features/support/world.js
+++ b/features/support/world.js
@@ -1,10 +1,8 @@
-var { defineSupportCode } = require('cucumber');
+var { setWorldConstructor } = require('cucumber');
 const testControllerHolder = require('./testControllerHolder');
 
 function CustomWorld () {
     this.waitForTestController = testControllerHolder.get;
 }
 
-defineSupportCode(function ({ setWorldConstructor }) {
-    setWorldConstructor(CustomWorld)
-});
+setWorldConstructor(CustomWorld)

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "./node_modules/.bin/cucumber-js.cmd"
   },
   "dependencies": {
-    "cucumber": "2.0.0-rc.9",
-    "testcafe": "^0.14.0"
+    "cucumber": "4.0.0",
+    "testcafe": "^0.19.0"
   }
 }


### PR DESCRIPTION
Thanks very much for creating this demo! It's really helpful to see how to integrate Cucumber.js and TestCafe together.

When running the tests I noticed the GitHub results step was failing. It looks like the DOM structure has changed, so I updated the selector to reflect the change. I also was having some issues with some extensions in my Chrome browser so I set it to incognito to get it to work. 

I also noticed this was using Cucumber 2 which is a couple major revisions back. I went ahead and updated to the newest version and made compatibility changes.

Let me know if there is anything that I could change differently.